### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/core/Application.js
+++ b/core/Application.js
@@ -3,7 +3,7 @@
 var Path = require('path');
 var Util = require('util');
 var Express = require('express');
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 var Diread = require('diread');
 
 var toArray = require('./helper/toArray');

--- a/core/Controller.js
+++ b/core/Controller.js
@@ -14,7 +14,7 @@ var addFunctions = require('./helper/pushElements');
 var addSlashToStringEnd = require('./helper/addSlashToStringEnd');
 
 var debug = require('debug')('ifnode:controller');
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 var Express = require('express');
 var Log = require('./extensions/log');
 

--- a/core/SchemaFactory.js
+++ b/core/SchemaFactory.js
@@ -6,7 +6,7 @@
  */
 
 
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 
 module.exports = function SchemaFactory() {
     /**

--- a/core/component.js
+++ b/core/component.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var UUID = require('node-uuid');
+var UUID = require('uuid');
 var toArray = require('./helper/toArray');
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-    "name": "ifnode",
-    "version": "1.5.1",
-    "description": "Node.js MVC Framework",
-    "main": "index.js",
-    "scripts": {
-        "test": "mocha --check-leaks"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/ilfroloff/ifnode.git"
-    },
-    "keywords": [
-        "mvc",
-        "framework"
-    ],
-    "author": "ilfroloff <ilfroloff@gmail.com> (https://twitter.com/ilfroloff)",
-    "license": "MIT",
-    "dependencies": {
-        "express": "4.14.0",
-        "sprintf": "0.1.5",
-        "diread": "0.2.0",
-        "lodash": "4.16.4",
-        "node-uuid": "1.4.7",
-        "debug": "2.2.0"
-    },
-    "devDependencies": {
-        "supertest": "1.1.x",
-        "mocha": "2.2.x",
-        "should": "6.0.x",
-        "eslint": "3.7.0",
-        "eslint-plugin-require-jsdoc": "1.0.x"
-    }
+  "name": "ifnode",
+  "version": "1.5.1",
+  "description": "Node.js MVC Framework",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha --check-leaks"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ilfroloff/ifnode.git"
+  },
+  "keywords": [
+    "mvc",
+    "framework"
+  ],
+  "author": "ilfroloff <ilfroloff@gmail.com> (https://twitter.com/ilfroloff)",
+  "license": "MIT",
+  "dependencies": {
+    "debug": "2.2.0",
+    "diread": "0.2.0",
+    "express": "4.14.0",
+    "lodash": "4.16.4",
+    "sprintf": "0.1.5",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "supertest": "1.1.x",
+    "mocha": "2.2.x",
+    "should": "6.0.x",
+    "eslint": "3.7.0",
+    "eslint-plugin-require-jsdoc": "1.0.x"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.